### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 [![NPM](https://nodei.co/npm/iran.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/iran/)
 
 # Administrative divisions of Iran
-##List of Iran cities in json and xml format based on administrative divisions of Iran.
+## List of Iran cities in json and xml format based on administrative divisions of Iran.
 sources: Pars html tables at [http://portal2.moi.ir/Portal/Home/Default.aspx?CategoryID=8f931308-c67e-4cf4-a5e7-3c1bbb1a6f32](http://portal2.moi.ir/Portal/Home/Default.aspx?CategoryID=8f931308-c67e-4cf4-a5e7-3c1bbb1a6f32)
 
 On the first level of country subdivisions of Iran are the provinces.
 Each province is further subdivided into counties called shahrestan (Persian: شهرستان shahrestān‎), and each shahrestan is subdivided into districts called bakhsh (Persian: بخش bakhsh‎). There are usually a few cities (Persian: شهر shahr‎) in each county.
 
-#Downloads (Right-click, and use "Save As")
+# Downloads (Right-click, and use "Save As")
 
  Version 1.0.2 [Source code (zip)](https://github.com/arastu/iran/archive/1.0.2.zip)
 
  Version 1.0.2 [Source code (tar.gz)](https://github.com/arastu/iran/archive/1.0.2.tar.gz)
 
-#Installation
+# Installation
 
 ```Node.js npm install iran```
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
